### PR TITLE
Test for filenames containing colons

### DIFF
--- a/config/software/discord.rb
+++ b/config/software/discord.rb
@@ -19,17 +19,21 @@
 # handling issues. Discord's makefile also creates hardlinks.
 
 name "discord"
-default_version "0.0.1"
+default_version "0.0.2"
 
 dependency "zlib"
 
-source url: "https://chef-releng.s3.amazonaws.com/discord-#{version}.tar.gz",
-       md5: "f16120be63e9c8c7597d3f30a5c2dd40"
+version("0.0.1") { source md5: "f16120be63e9c8c7597d3f30a5c2dd40" }
+version("0.0.2") { source md5: "58c54b48517a8359f219e926f89f39e7" }
+
+source url: "https://chef-releng.s3.amazonaws.com/discord/discord-#{version}.tar.gz"
 
 relative_path "discord-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  env['PREFIX'] = "#{install_dir}/embedded"
+
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env
 end

--- a/omnibus.rb
+++ b/omnibus.rb
@@ -32,10 +32,10 @@ use_git_caching false
 
 # Enable S3 asset caching
 # ------------------------------
-# use_s3_caching true
+use_s3_caching true
 # s3_access_key  ENV['S3_ACCESS_KEY']
 # s3_secret_key  ENV['S3_SECRET_KEY']
-# s3_bucket      ENV['S3_BUCKET']
+s3_bucket      'opscode-omnibus-cache'
 
 # Customize compiler bits
 # ------------------------------
@@ -49,3 +49,4 @@ build_retries 0
 # ------------------------------
 # software_gems ['omnibus-software', 'my-company-software']
 # local_software_dirs ['/path/to/local/software']
+append_timestamp false


### PR DESCRIPTION
Add second discord version with colon filenames.

This accommodates a test case on AIX regarding a .bff package containing file paths with colons in them, on which the installp command chokes.

This points to a discord tarball containing: https://gist.github.com/curiositycasualty/d83016b7f1bcc865354b/b0e1fb6862e43bf1965a223bbaf6c444af59049d

