### PR TITLE
new version of discord; now creates single colon filename

### DIFF
--- a/config/software/discord.rb
+++ b/config/software/discord.rb
@@ -19,12 +19,13 @@
 # handling issues. Discord's makefile also creates hardlinks.
 
 name "discord"
-default_version "0.0.2"
+default_version "0.0.3"
 
 dependency "zlib"
 
 version("0.0.1") { source md5: "f16120be63e9c8c7597d3f30a5c2dd40" }
 version("0.0.2") { source md5: "58c54b48517a8359f219e926f89f39e7" }
+version("0.0.3") { source md5: "beb362dd00d36b983e59b1c6c0f4e41f" }
 
 source url: "https://chef-releng.s3.amazonaws.com/discord/discord-#{version}.tar.gz"
 


### PR DESCRIPTION
https://gist.github.com/curiositycasualty/d83016b7f1bcc865354b/download#file-makefile-L17
```
 install: ./discord
 	mkdir -p $(PREFIX)/share/man/man3/ && \
+	touch $(PREFIX)/share/man/man3/Single:Colon && \
 	touch $(PREFIX)/share/man/man3/Tie::Memoize.3 && \
 	touch $(PREFIX)/share/man/man3/App::Cpan.3 && \
```