### PR TITLE
Ensure we produce a `*.dmg` when built on Mac OS X

### DIFF
--- a/config/projects/harmony.rb
+++ b/config/projects/harmony.rb
@@ -30,6 +30,7 @@ exclude 'man\/'
 package :pkg do
   identifier 'com.getchef.harmony'
 end
+compress :dmg
 
 package :msi do
   upgrade_code '3AA89B1F-D8F3-4D46-8CB2-534C8313DBFD'


### PR DESCRIPTION
/cc @chef/engineering-services 