### PR TITLE
Use native `.tar.lzma` support in `Omnibus::NetFetcher`

### DIFF
--- a/config/software/libyaml-windows.rb
+++ b/config/software/libyaml-windows.rb
@@ -20,20 +20,11 @@ default_version "0.1.6"
 source url: "http://packages.openknapsack.org/libyaml/libyaml-0.1.6-x86-windows.tar.lzma",
        md5: "8bb5d8e43cf18ec48b4751bdd0111c84"
 
+# ugh...See https://github.com/chef/omnibus-harmony/pull/10#issuecomment-161490982
+relative_path 'bin'
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  tmpdir = File.join(Omnibus::Config.cache_dir, "libyaml-cache")
-
-  # Ensure the directory exists
-  mkdir tmpdir
-
-  # First extract the tar file out of lzma archive.
-  command "7z.exe x #{project_file} -o#{tmpdir} -r -y", env: env
-
-  # Now extract the files out of tar archive.
-  command "7z.exe x #{File.join(tmpdir, "libyaml-0.1.6-x86-windows.tar")} -o#{tmpdir} -r -y", env: env
-
-  # Now copy over libyaml-0-2.dll to the build dir
-  copy "#{tmpdir}/bin/libyaml-0-2.dll", "#{install_dir}/embedded/bin/libyaml-0-2.dll"
+  copy "libyaml-0-2.dll", "#{install_dir}/embedded/bin/libyaml-0-2.dll"
 end


### PR DESCRIPTION
See chef/omnibus#572 for full details.

Test CI run: http://manhattan.ci.chef.co/job/harmony-trigger-ad_hoc/24/downstreambuildview/

/cc @chef/engineering-services 