### PR TITLE
Update discord to 0.0.5 with more symlinks

### DIFF
--- a/config/software/discord.rb
+++ b/config/software/discord.rb
@@ -19,12 +19,13 @@
 # handling issues. Discord's makefile also creates hardlinks.
 
 name "discord"
-default_version "0.0.2"
+default_version "0.0.5"
 
 dependency "zlib"
 
 version("0.0.1") { source md5: "f16120be63e9c8c7597d3f30a5c2dd40" }
 version("0.0.2") { source md5: "58c54b48517a8359f219e926f89f39e7" }
+version("0.0.5") { source md5: "d8993994f54f624c830518c483ac43f9" }
 
 source url: "https://chef-releng.s3.amazonaws.com/discord/discord-#{version}.tar.gz"
 


### PR DESCRIPTION
[DIscord's Makfile](https://gist.github.com/curiositycasualty/d83016b7f1bcc865354b#file-makefile) now has these lines for the `make install` task:
```
install: ./discord
	mkdir -p $(PREFIX)/share/man/man3/ && \
	touch $(PREFIX)/share/man/man3/Single:Colon && \
	touch $(PREFIX)/share/man/man3/Single\ Space && \
	touch $(PREFIX)/share/man/man3/.dotfile && \
	touch $(PREFIX)/share/man/man3/.dotfile.with.ext && \
	touch $(PREFIX)/share/man/man3/Tie::Memoize.3 && \
	touch $(PREFIX)/share/man/man3/App::Cpan.3 && \
	touch $(PREFIX)/share/man/man3/Pod::Simple::PullParserToken.3 && \
	mkdir -p $(PREFIX)/bin && \
	cp ./discord $(PREFIX)/bin/discord && \
	ln -f $(PREFIX)/bin/discord $(PREFIX)/bin/chaos && \
	ln -f $(PREFIX)/bin/discord $(PREFIX)/bin/entropy && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/bedlam && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/four && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/five && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/six && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/seven && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/eight && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/nine && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/ten && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/eleven && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/twelve && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/thirteen && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/fourteen && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/fifteen && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/sixteen && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/seventeen && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/eighteen && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/nineteen && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/twenty && \
<and onward...>
```

This emulates an issue currently being faced within omnibus-toolchain where a built package which include git fails to install:
```
installp: APPLYING software for:
	angry-omnibus-toolchain 1.1.1.1

youtube.com/watch?v=Xs-tl6GBOBo
sysck: 3001-018 An error was encountered reading the input file.
sysck: 3001-019 The last valid stanza read was /opt/angry-omnibus-toolchain/embedded/bin/gem.
sysck: 3001-017 Errors were detected validating the files
	for package angry-omnibus-toolchain.

installp:  The installation has FAILED for the "usr" part 
	of the following filesets:
	angry-omnibus-toolchain 1.1.1.1

installp: Cleaning up software for:
	angry-omnibus-toolchain 1.1.1.1

Finished processing all filesets.  (Total time:  1 mins 29 secs).
```

With the stanza in question referring to the 110 symlinks to Git's binary:
```
/opt/angry-omnibus-toolchain/embedded/bin/gem:
          owner = root
          group = system
          mode = 755
          type = FILE
          class = apply,inventory,angry-omnibus-toolchain
          size = 916
          checksum = "36344    1 "

/opt/angry-omnibus-toolchain/embedded/bin/git:
          owner = root
          group = system
          mode = 755
          type = FILE
          links = /opt/angry-omnibus-toolchain/embedded/bin/git-receive-pack,/opt/angry-omnibus-toolchain/embedded/bin/git-upload-archive,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-add,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-annotate,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-apply,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-archive,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-bisect--helper,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-blame,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-branch,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-bundle,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-cat-file,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-check-attr,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-check-ignore,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-check-mailmap,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-check-ref-format,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-checkout,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-checkout-index,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-cherry,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-cherry-pick,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-clean,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-clone,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-column,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-commit,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-commit-tree,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-config,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-count-objects,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-credential,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-describe,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-diff,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-diff-files,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-diff-index,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-diff-tree,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-fast-export,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-fetch,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-fetch-pack,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-fmt-merge-msg,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-for-each-ref,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-format-patch,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-fsck,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-fsck-objects,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-gc,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-get-tar-commit-id,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-grep,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-hash-object,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-help,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-index-pack,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-init,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-init-db,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-log,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-ls-files,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-ls-remote,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-ls-tree,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-mailinfo,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-mailsplit,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-merge,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-merge-base,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-merge-file,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-merge-index,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-merge-ours,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-merge-recursive,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-merge-subtree,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-merge-tree,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-mktag,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-mktree,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-mv,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-name-rev,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-notes,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-pack-objects,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-pack-redundant,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-pack-refs,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-patch-id,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-prune,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-prune-packed,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-push,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-read-tree,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-receive-pack,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-reflog,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-remote,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-remote-ext,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-remote-fd,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-repack,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-replace,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-rerere,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-reset,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-rev-list,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-rev-parse,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-revert,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-rm,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-send-pack,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-shortlog,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-show,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-show-branch,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-show-ref,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-stage,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-status,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-stripspace,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-symbolic-ref,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-tag,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-unpack-file,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-unpack-objects,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-update-index,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-update-ref,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-update-server-info,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-upload-archive,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-var,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-verify-pack,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-verify-tag,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-whatchanged,/opt/angry-omnibus-toolchain/embedded/libexec/git-core/git-write-tree
          class = apply,inventory,angry-omnibus-toolchain
          size = 3395580
          checksum = "32003    3316 “
```

And relates to the omnbus changes (https://github.com/chef/omnibus/pull/585) that would print the inventory when in `log_level` `:debug`.

/cc @chef/omnibus-maintainers @chef/engineering-services 