### PR TITLE
Makes discord links less symmy

### DIFF
--- a/config/software/discord.rb
+++ b/config/software/discord.rb
@@ -19,13 +19,14 @@
 # handling issues. Discord's makefile also creates hardlinks.
 
 name "discord"
-default_version "0.0.5"
+default_version "0.0.6"
 
 dependency "zlib"
 
 version("0.0.1") { source md5: "f16120be63e9c8c7597d3f30a5c2dd40" }
 version("0.0.2") { source md5: "58c54b48517a8359f219e926f89f39e7" }
 version("0.0.5") { source md5: "d8993994f54f624c830518c483ac43f9" }
+version("0.0.6") { source md5: "37eff013cdd48f16eb51061513593cb3" }
 
 source url: "https://chef-releng.s3.amazonaws.com/discord/discord-#{version}.tar.gz"
 


### PR DESCRIPTION
The link apparently need to not be symlinks in order to generate the desired stanza in the control file.

With discord 0.0.5, we got:
```
/opt/harmony/embedded/bin/eight:
          type = SYMLINK
          class = apply,inventory,harmony
          target = /opt/harmony/embedded/bin/discord

/opt/harmony/embedded/bin/eighteen:
          type = SYMLINK
          class = apply,inventory,harmony
          target = /opt/harmony/embedded/bin/discord

/opt/harmony/embedded/bin/eighty:
          type = SYMLINK
          class = apply,inventory,harmony
          target = /opt/harmony/embedded/bin/discord
```

/cc @chef/engineering-services 