### PR TITLE
discord 0.0.8 w/o 110 links

### DIFF
--- a/config/software/discord.rb
+++ b/config/software/discord.rb
@@ -19,7 +19,7 @@
 # handling issues. Discord's makefile also creates hardlinks.
 
 name "discord"
-default_version "0.0.7"
+default_version "0.0.8"
 
 dependency "zlib"
 
@@ -28,6 +28,7 @@ version("0.0.2") { source md5: "58c54b48517a8359f219e926f89f39e7" }
 version("0.0.5") { source md5: "d8993994f54f624c830518c483ac43f9" }
 version("0.0.6") { source md5: "37eff013cdd48f16eb51061513593cb3" }
 version("0.0.7") { source md5: "9a314b69fb7a41fa3692553fbb071872" }
+version("0.0.8") { source md5: "984cf3016820dac7b2e4a8804d01e4ac" }
 
 source url: "https://chef-releng.s3.amazonaws.com/discord/discord-#{version}.tar.gz"
 


### PR DESCRIPTION
Makefile looks like this again:
```
install: ./discord
	mkdir -p $(PREFIX)/share/man/man3/ && \
	touch $(PREFIX)/share/man/man3/Single:Colon && \
	touch $(PREFIX)/share/man/man3/.dotfile && \
	touch $(PREFIX)/share/man/man3/.dotfile.with.ext && \
	touch $(PREFIX)/share/man/man3/Tie::Memoize.3 && \
	touch $(PREFIX)/share/man/man3/App::Cpan.3 && \
	touch $(PREFIX)/share/man/man3/Pod::Simple::PullParserToken.3 && \
	mkdir -p $(PREFIX)/bin && \
	cp ./discord $(PREFIX)/bin/discord && \
	ln -f $(PREFIX)/bin/discord $(PREFIX)/bin/chaos && \
	ln -f $(PREFIX)/bin/discord $(PREFIX)/bin/entropy && \
	ln -sf $(PREFIX)/bin/discord $(PREFIX)/bin/bedlam
```
/cc @chef/engineering-services 