### PR TITLE
Add delay buffer to prevent erronious harmony builds

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -9,6 +9,17 @@ github:
   # The Github Team primarily responsible for handling incoming Pull Requests.
   maintainer_group: chef/engineering-services
 
+buffers:
+  # If multiple PRs are merged into omnibus-software within 10 minutes of each other,
+  # only trigger a build once. Defer execution at most two times before building anyways.
+  - cache_builds:
+      type: delay
+      workload_type: github_pull_request
+      delay: 600
+      max_deferments: 2
+      actions:
+        - built_in:trigger_omnibus_expcache_build
+
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:
   - built_in:trigger_omnibus_build:
@@ -23,4 +34,4 @@ subscriptions:
   # chef/omnibus-software
   - workload: pull_request_merged:chef/omnibus-software:master:*
     actions:
-      - built_in:trigger_omnibus_expcache_build
+      - buffer:cache_builds


### PR DESCRIPTION
If multiple omnibus-software PRs are merged within 10 minutes of each other, only trigger a build for the most recent PR.

Signed-off-by: Tom Duffield <tom@chef.io>