### PR TITLE
Add adhoc canary pipeline

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -25,6 +25,11 @@ pipelines:
       env:
         - ADHOC: true
         - EXPIRE_CACHE: true
+  - omnibus/adhoc-canary:
+      canary: true
+      definition: .expeditor/adhoc.omnibus.yml
+      env:
+        - ADHOC: true
 
 subscriptions:
   - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*


### PR DESCRIPTION
This will allow us to run the Omnibus build in the canary organization to test changes to Expeditor and/or the Buildkite plugin.
