### PR TITLE
IPACK-126 Update platforms

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -11,6 +11,8 @@ builder-to-testers-map:
   # aix-7.1-powerpc:
   #   - aix-7.1-powerpc
   #   - aix-7.2-powerpc
+  amazon-2022-aarch64:
+    - amazon-2022-aarch64
   amazon-2022-x86_64:
     - amazon-2022-x86_64
   debian-9-x86_64:
@@ -41,8 +43,7 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
-  freebsd-11-amd64:
-    - freebsd-11-amd64
+  freebsd-12-amd64:
     - freebsd-12-amd64
     - freebsd-13-amd64
   mac_os_x-10.15-x86_64:
@@ -67,10 +68,12 @@ builder-to-testers-map:
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
+    - ubuntu-22.04-aarch64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
+    - ubuntu-22.04-x86_64
   windows-2012r2-i386:
     - windows-2012r2-i386
   windows-2012r2-x86_64:

--- a/.expeditor/adhoc.omnibus.yml
+++ b/.expeditor/adhoc.omnibus.yml
@@ -10,6 +10,8 @@ builder-to-testers-map:
   aix-7.1-powerpc:
     - aix-7.1-powerpc
     - aix-7.2-powerpc
+  amazon-2022-aarch64:
+    - amazon-2022-aarch64
   amazon-2022-x86_64:
     - amazon-2022-x86_64
   debian-9-x86_64:
@@ -40,8 +42,7 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
-  freebsd-11-amd64:
-    - freebsd-11-amd64
+  freebsd-12-amd64:
     - freebsd-12-amd64
     - freebsd-13-amd64
   mac_os_x-10.15-x86_64:
@@ -66,10 +67,12 @@ builder-to-testers-map:
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
+    - ubuntu-22.04-aarch64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
+    - ubuntu-22.04-x86_64
   windows-2012r2-i386:
     - windows-2012r2-i386
   windows-2012r2-x86_64:


### PR DESCRIPTION
Add amazon linux 2022 arm64 and Ubuntu 22.04 arm64 and amd64.

Remove FreeBSD 11.